### PR TITLE
adding info about the duo_api_php package to duo_php README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Or add the following to your project:
 }
 ```
 
+> **NOTE:** In order for the example in the `demos/simple-v2` directory to work, you will also need to use Composer to install the [duo_api_php package](https://github.com/duosecurity/duo_api_php).
+
 # Using
 
 ```


### PR DESCRIPTION
As the example in the `demos/simple-v2` makes use of the `\DuoAPI` classes and relies on Composer to autoload them, I've added a mention of this requirement to the `README`. There are no functional changes in this PR.